### PR TITLE
Catch only Settings.SettingNotFoundException in OverlayServiceFactory

### DIFF
--- a/app/src/main/kotlin/com/jereksel/libresubstratum/domain/OverlayServiceFactory.kt
+++ b/app/src/main/kotlin/com/jereksel/libresubstratum/domain/OverlayServiceFactory.kt
@@ -28,7 +28,7 @@ object OverlayServiceFactory {
         try {
             Settings.Secure.getInt(context.contentResolver, "force_authorize_substratum_packages")
             log.debug("force_authorize_substratum_packages supported")
-        } catch (e: Exception) {
+        } catch (e: Settings.SettingNotFoundException) {
             log.error("force_authorize_substratum_packages not supported", e)
             return InvalidOverlayService("Your ROM is too old to support this app (3-rd party apps in Interfacer are not supported)")
         }


### PR DESCRIPTION
Closes #53 