### PR TITLE
Remove checking if force_authorize_substratum_packages exists

### DIFF
--- a/app/src/main/kotlin/com/jereksel/libresubstratum/domain/OverlayServiceFactory.kt
+++ b/app/src/main/kotlin/com/jereksel/libresubstratum/domain/OverlayServiceFactory.kt
@@ -32,14 +32,6 @@ object OverlayServiceFactory {
             return InvalidOverlayService("Interfacer is not installed. Are you using Substratum compatible ROM?")
         }
 
-        try {
-            Settings.Secure.getInt(context.contentResolver, "force_authorize_substratum_packages")
-            log.debug("force_authorize_substratum_packages supported")
-        } catch (e: Settings.SettingNotFoundException) {
-            log.error("force_authorize_substratum_packages not supported")
-            return InvalidOverlayService("Your ROM is too old to support this app (3-rd party apps in Interfacer are not supported)")
-        }
-
         if (isNewInterfacerPermissionAvailable(context)) {
             log.debug("DU commits available")
             return WDUCommitsOverlayService(context)

--- a/app/src/main/kotlin/com/jereksel/libresubstratum/domain/overlayService/nougat/WODUCommitsOverlayService.kt
+++ b/app/src/main/kotlin/com/jereksel/libresubstratum/domain/overlayService/nougat/WODUCommitsOverlayService.kt
@@ -16,7 +16,7 @@ open class WODUCommitsOverlayService(context: Context): InterfacerOverlayService
             return "Please install Substratum app (it's required for Interfacer to function properly)"
         }
 
-        val areAllPackagesAllowed = Settings.Secure.getInt(context.contentResolver, "force_authorize_substratum_packages") == 1
+        val areAllPackagesAllowed = Settings.Secure.getInt(context.contentResolver, "force_authorize_substratum_packages", 0) == 1
 
         return if (!areAllPackagesAllowed) {
             """Please turn on "Force authorize every theme app" in developer settings"""

--- a/app/src/main/play/en-US/whatsnew-beta
+++ b/app/src/main/play/en-US/whatsnew-beta
@@ -1,3 +1,4 @@
+Fix "Your ROM is too old to support this app" message
 Support for encrypted themes
 About screen
 Fix some issues with uninstalling


### PR DESCRIPTION
It's buggy (on devices where there toggle wasn't touched I go
NameNotFoundException) and unnecessary (your rom must be very
old if you don't have this)

Closes #126